### PR TITLE
Rename back to ilib-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# ilib-webpack-plug-in
+# ilib-webpack-plugin
 
-ilib-webpack-plug-in is a webpack plugin for ilib so that you can use ilib in your
+IF YOU ARE USING ilib-webpack-plugin WITH OLD ENYO BUILDS, THIS VERSION IS NOT THE
+ONE YOU ARE LOOKING FOR. You need the older version < 1.0.0. Make sure to specify
+that in your package.json.
+
+ilib-webpack-plugin is a webpack plugin for ilib so that you can use ilib in your
 own webpack project and
 only include the ilib classes and locale data that you actually need. It can also be used
 to create a custom version of ilib, even if you are not using webpack in your own
 project.
 
-To use iLib in your own project, you will need both the ilib-webpack-plug-in and the
-ilib-webpack-loader together.
-
-Be careful of the spelling of the repo name -- the enyojs project has named
-"ilib-webpack-plugin" which is different and cannot be used with the ilb
-loader to build ilib, except if you are building it for Enyo or Enact.
+To use iLib in your own project, you will need both the ilib-webpack-plugin and the
+ilib-webpack-loader together, both with versions > 1.0.0.
 
 The full documentation for the use of this plugin and the loader together is in the
 [ilib-webpack-loader project](http://github.com/ilib-js/ilib-webpack-loader).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "ilib-webpack-plug-in",
-    "version": "0.9.1",
+    "name": "ilib-webpack-plugin",
+    "version": "1.0.0",
     "main": "./ilib-webpack-plugin.js",
     "description": "A plug in for webpack that knows how to load ilib locale data files.",
     "license": "Apache-2.0",
@@ -41,7 +41,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/iLib-js/ilib-webpack-plug-in.git"
+        "url": "https://github.com/iLib-js/ilib-webpack-plugin.git"
     },
     "engines": {
         "node": ">=0.12"


### PR DESCRIPTION
The enyo folks have ceded ownership of that name on npm to the ilib project.
Consequently, we are renaming this project back again, and we are moving the
version number up to 1.0.0 so that it doesn't conflict with the old enyo
version of ilib-webpack-plugin.