### PR TITLE
Fix ilib loading

### DIFF
--- a/ilib-webpack-plugin.js
+++ b/ilib-webpack-plugin.js
@@ -437,8 +437,8 @@ function emitLocaleData(compilation, options) {
 
 function IlibDataPlugin(options) {
     this.options = options;
-    
-    loadIlibClasses();
+
+    loadIlibClasses(options.ilibRoot);
 }
 
 IlibDataPlugin.prototype.apply = function(compiler) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-plugin",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "./ilib-webpack-plugin.js",
     "description": "A plug in for webpack that knows how to load ilib locale data files.",
     "license": "Apache-2.0",
@@ -50,6 +50,6 @@
         "test": "ant test"
     },
     "dependencies": {
-        "ilib": ">13.0.0"
+        "ilib": "^14.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
         "test": "ant test"
     },
     "dependencies": {
-        "ilib": "^14.0.0"
+        "ilib": "^14.1.0"
     }
 }


### PR DESCRIPTION
The plugin was not heeding the ilibRoot option, which meant that it would not work with both local ilib clone and with an npm install. Now it does!