### PR TITLE
Fix absolute dir

### DIFF
--- a/ilib-webpack-plugin.js
+++ b/ilib-webpack-plugin.js
@@ -129,7 +129,7 @@ function emitLocaleData(compilation, options) {
     var outputFileName, output;
     var scripts = new Set();
     var normalizations = {};
-    var outputDir = path.resolve(path.join(process.cwd(), options.tempDir || 'assets'));
+    var outputDir = path.resolve(path.isAbsolute(options.tempDir) ? options.tempDir : path.join(process.cwd(), options.tempDir || 'assets'));
     var sources = {};
 
     var charsets = new Set();
@@ -536,7 +536,7 @@ IlibDataPlugin.prototype.getDummyLocaleDataFiles = function(compilation) {
     var outputSet = new Set();
 
     var locales = this.options.locales;
-    var tempDir = path.resolve(path.join(process.cwd(), this.options.tempDir || 'assets'));
+    var tempDir = path.resolve(path.isAbsolute(options.tempDir) ? options.tempDir : path.join(process.cwd(), this.options.tempDir || 'assets'));
 
     if (this.options.debug) console.log("Creating locale data for locales " + locales.join(","));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-plugin",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./ilib-webpack-plugin.js",
     "description": "A plug in for webpack that knows how to load ilib locale data files.",
     "license": "Apache-2.0",


### PR DESCRIPTION
If the tempDir option was specified as an absolute path, then this plugin didn't work. The fix is simple -- don't prepend the current working directory if the path is absolute. Only do it when it is specified as a relative path.