### PR TITLE
Add webpack4 support!

### DIFF
--- a/ilib-webpack-plugin.js
+++ b/ilib-webpack-plugin.js
@@ -448,11 +448,21 @@ function IlibDataPlugin(options) {
 }
 
 IlibDataPlugin.prototype.apply = function(compiler) {
-    compiler.plugin('compilation', function(compilation, callback) {
+    // webpack 4.X or 3.X?
+    var compilationHook = (typeof(compiler.hooks) !== "undefined") ?
+        compiler.hooks.compilation.tap.bind(compiler.hooks.compilation, 'IlibDataPlugin') :
+        compiler.plugin.bind(compiler, 'compilation');
+
+    compilationHook(function(compilation, callback) {
         // console.log("@@@@@@@@@@@@@@@@ compilation");
         compilation.ilibWebpackPlugin = this; // make sure the ilib webpack loaders can find this plugin
 
-        compilation.plugin('finish-modules', function(modules) {
+        // webpack 4.X or 3.X?
+        var finishModulesHook = (typeof(compilation.hooks) !== "undefined") ?
+            compilation.hooks.finishModules.tap.bind(compilation.hooks.finishModules, 'IlibDataPlugin') :
+            compilation.plugin.bind(compilation, 'finish-modules');
+
+        finishModulesHook(function(modules) {
             // console.log("@@@@@@@@@@@@@@@@ finish-modules");
             if (localeData.size > 0) {
                 try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-webpack-plugin",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "main": "./ilib-webpack-plugin.js",
     "description": "A plug in for webpack that knows how to load ilib locale data files.",
     "license": "Apache-2.0",


### PR DESCRIPTION
It now detects if it is running in webpack 3 or 4 and registers the right callback for its environment. The core of what it does stays the same though. I have tested this with both webpack 3.12.0 and webpack 4.32.2 on ilib's demo site and it seems to work fine.